### PR TITLE
Release v0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-[Unreleased]
+## [0.14] - 2023-11-14
 
 ### Changed
 
@@ -64,7 +64,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - First release.
 
-[unreleased]: https://github.com/nuncard/tfadm/compare/v0.13...HEAD
+[unreleased]: https://github.com/nuncard/tfadm/compare/v0.14...HEAD
+[0.14]: https://github.com/nuncard/tfadm/compare/v0.13...v0.14
 [0.13]: https://github.com/nuncard/tfadm/compare/v0.12...v0.13
 [0.12]: https://github.com/nuncard/tfadm/compare/v0.11.0...v0.12
 [0.11.0]: https://github.com/nuncard/tfadm/releases/tag/v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `create` command calls a duplicate of `cli_update` function;
 - Improved `Update` method debug messages;
 - Use default value if value is null;
-- Do not convert null values to string.
+- Do not convert null values to string;
+- Parse an existing path even if it is not full.
 
 ## [0.13] - 2023-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
-- `create` command calls a duplicate of `cli_update` function.
+- `create` command calls a duplicate of `cli_update` function;
+- Improved `Update` method debug messages;
+- Use default value if value is null.
 
 ## [0.13] - 2023-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `create` command calls a duplicate of `cli_update` function;
 - Improved `Update` method debug messages;
-- Use default value if value is null.
+- Use default value if value is null;
+- Do not convert null values to string.
 
 ## [0.13] - 2023-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [Unreleased]
 
+### Changed
+
+- By default ignore `variable` resource inherited properties that do not have a description;
+
 ### Fixed
 
 - `create` command calls a duplicate of `cli_update` function;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Improved `Update` method debug messages;
 - Use default value if value is null;
 - Do not convert null values to string;
-- Parse an existing path even if it is not full.
+- Parse an existing path even if it is not full;
+- Virtual path inherited out of order.
 
 ## [0.13] - 2023-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+[Unreleased]
+
+### Fixed
+
+- `create` command calls a duplicate of `cli_update` function.
+
 ## [0.13] - 2023-10-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Use default value if value is null;
 - Do not convert null values to string;
 - Parse an existing path even if it is not full;
-- Virtual path inherited out of order.
+- Virtual path inherited out of order;
+- Refactored `Resource.trigger()` method;
 
 ## [0.13] - 2023-10-08
 

--- a/src/tfadm/__init__.py
+++ b/src/tfadm/__init__.py
@@ -1,2 +1,2 @@
 # For acceptable version formats, see https://www.python.org/dev/peps/pep-0440/
-__version__ = '0.13'
+__version__ = '0.14'

--- a/src/tfadm/__main__.py
+++ b/src/tfadm/__main__.py
@@ -134,7 +134,7 @@ With RESOURCE, dump resource configuration to stdout.
 )
 @click.argument('resource')
 @click.argument('path', required=False, nargs=-1)
-def cli_update(resource, path=None, **opts):
+def cli_create(resource, path=None, **opts):
   """Creates an object from stdin.
 
 RESOURCE must be specified. Use 'tfadm resources' for a complete list of
@@ -149,7 +149,7 @@ If the object already exists, tfadm will error out, unless the '-o', or
   resource = Resources().load(resource)
 
   for args in read_args(resource, path):
-    resource('create', args, **opts)
+    resource('create', args, defaults=True, **opts)
 
 @cli.command('update')
 @click.option(

--- a/src/tfadm/methods/update.py
+++ b/src/tfadm/methods/update.py
@@ -25,7 +25,7 @@ class Update(Method):
     pk = props.primarykey(args_, pk_, required)
 
     if required:
-      pprint({context + '.primary_key': pk})
+      pprint({context + '.args': args_})
       raise RequiredArgument(context, ', '.join(required))
 
     merge(pk_, pk)

--- a/src/tfadm/path.py
+++ b/src/tfadm/path.py
@@ -1,7 +1,6 @@
 from .settings import get, update
 from collections import UserList
 from collections.abc import Mapping
-from os.path import dirname
 from parse import parse
 from pathlib import Path, PurePosixPath
 import re
@@ -24,14 +23,10 @@ class VirtualPath(UserList):
     path = Path(path)
 
     if not resource.source.startswith(this) and path.is_dir():
-      mapping = parse(dirname(self.owner.source), self.join(*path.parts), case_sensitive=True)
+      source = PurePosixPath(self.owner.source)
+      mapping = parse(self.join(*source.parts[0:len(path.parts)]), self.join(*path.parts), case_sensitive=True)
       args = mapping.named if mapping else {}
-
-      try:
-        self.owner.source.format_map(args)
-        return args
-      except:
-        pass
+      return args
 
     parts = path.parts
 

--- a/src/tfadm/path.py
+++ b/src/tfadm/path.py
@@ -1,7 +1,6 @@
 from .settings import get, update
 from collections import UserList
 from collections.abc import Mapping
-from os.path import dirname
 from parse import parse
 from pathlib import Path, PurePosixPath
 import re

--- a/src/tfadm/path.py
+++ b/src/tfadm/path.py
@@ -1,6 +1,7 @@
 from .settings import get, update
 from collections import UserList
 from collections.abc import Mapping
+from os.path import dirname
 from parse import parse
 from pathlib import Path, PurePosixPath
 import re
@@ -52,13 +53,14 @@ class VirtualPath(UserList):
 
   def _inherit(self):
     parent = self.owner.parent
-    inherited = []
 
-    def inherit(key, prop):
-      if key in parent.path and prop.get('inherit', True):
-        inherited.append(key)
+    if parent and parent.path:
+      inherited = [*parent.path]
 
-    if parent:
+      def inherit(key, prop):
+        if key in parent.path and not prop.get('inherit', True):
+          inherited.remove(key)
+
       parent.properties.walk(inherit)
 
       if inherited:

--- a/src/tfadm/properties.py
+++ b/src/tfadm/properties.py
@@ -145,7 +145,7 @@ def init(properties:Mapping, args:Mapping, defaults:bool=True, slugs:bool=True, 
     else:
       primary_key = prop.get('primary_key', False)
 
-      if defaults and value is None and (primary_key or prop.get('ignore', False)):
+      if defaults and value is None:
         try:
           value = getformat(prop, 'default', args_)
         except:

--- a/src/tfadm/properties.py
+++ b/src/tfadm/properties.py
@@ -14,10 +14,11 @@ import re
 slugify_regex = r'[^-a-zA-Z0-9_]+'
 
 def compute(prop:Mapping, value, args:Mapping):
-  type_ = prop.get('type')
+  if value is not None:
+    type_ = prop.get('type')
 
-  if type_ in ['json', 'string'] and not isinstance(value, str):
-    value = json_encode(value)
+    if type_ in ['json', 'string'] and not isinstance(value, str):
+      value = json_encode(value)
 
   translator = prop.get('translate')
 

--- a/src/tfadm/properties.py
+++ b/src/tfadm/properties.py
@@ -388,8 +388,10 @@ class Properties(UserDict):
         if resource.address == 'variable':
           for prop in inherited.values():
             prop.pop('computed', None)
-            prop.pop('ignore', False)
             prop.setdefault('type', 'string')
+
+            if prop.get('description'):
+              prop.pop('ignore', False)
 
         self.data = merge(inherited, self.data)
 


### PR DESCRIPTION
## Changed

- By default ignore `variable` resource inherited properties that do not have a description;

## Fixed

- `create` command calls a duplicate of `cli_update` function;
- Improved `Update` method debug messages;
- Use default value if value is null;
- Do not convert null values to string;
- Parse an existing path even if it is not full;
- Virtual path inherited out of order;
- Refactored `Resource.trigger()` method;