### PR TITLE
Released v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.14.1] - 2023-11-25
 
 ### Fixed
 
@@ -70,7 +70,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - First release.
 
-[unreleased]: https://github.com/nuncard/tfadm/compare/v0.14...HEAD
+[unreleased]: https://github.com/nuncard/tfadm/compare/v0.14.1...HEAD
+[0.14.1]: https://github.com/nuncard/tfadm/compare/v0.14...v0.14.1
 [0.14]: https://github.com/nuncard/tfadm/compare/v0.13...v0.14
 [0.13]: https://github.com/nuncard/tfadm/compare/v0.12...v0.13
 [0.12]: https://github.com/nuncard/tfadm/compare/v0.11.0...v0.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `methods/sync/when` clause not applied when parent arguments are missing.
+
 ## [0.14] - 2023-11-14
 
 ### Changed

--- a/src/tfadm/__init__.py
+++ b/src/tfadm/__init__.py
@@ -1,2 +1,2 @@
 # For acceptable version formats, see https://www.python.org/dev/peps/pep-0440/
-__version__ = '0.14'
+__version__ = '0.14.1'


### PR DESCRIPTION
## Fixed

- `methods/sync/when` clause not applied when parent arguments are missing.